### PR TITLE
Added explicit STOP and PREP phases

### DIFF
--- a/TimerControlBox.cpp
+++ b/TimerControlBox.cpp
@@ -143,7 +143,7 @@ int TimerControlBox::next_end_command(int end_number, bool practice_flag)
 
 	// State the callup time in the timer display, and enable the
 	// GO button.
-      timer_window_->set_time_value(timer_callup_, TimerMain::TIMER_CALLUP);
+      timer_window_->set_time_value(timer_callup_, TimerMain::TIMER_PREP);
       ui->go_button->setEnabled(true);
 
 	// Return the number for the next end.

--- a/TimerMain.cpp
+++ b/TimerMain.cpp
@@ -68,23 +68,32 @@ void TimerMain::set_line_text(const class QString&txt)
 
 void TimerMain::set_time_value(int val, timer_mode_t mode)
 {
+      QString val_text;
+      val_text.setNum(val);
+	
       switch (mode) {
 	  case TIMER_CALLUP:
 	    ui->timer_text->setPalette(red_);
+		ui->timer_text->setText(val_text);
 	    break;
 	  case TIMER_END:
 	    ui->timer_text->setPalette(green_);
+		ui->timer_text->setText(val_text);
 	    break;
 	  case TIMER_END_WARN:
 	    ui->timer_text->setPalette(yellow_);
+		ui->timer_text->setText(val_text);
 	    break;
-	  case TIMER_STOP:
-	    ui->timer_text->setPalette(red_);
-	    break;
+  	  case TIMER_STOP:
+  	    ui->timer_text->setPalette(red_);
+  		ui->timer_text->setText("STOP");
+  	    break;
+      case TIMER_PREP:
+    	ui->timer_text->setPalette(red_);
+    	ui->timer_text->setText("PREP");
+    	break;
       }
-      QString val_text;
-      val_text.setNum(val);
-      ui->timer_text->setText(val_text);
+
 }
 
 bool TimerMain::toggle_fullscreen(void)

--- a/TimerMain.h
+++ b/TimerMain.h
@@ -43,7 +43,7 @@ class TimerMain : public QMainWindow
 	// Set the text for the active line display.
       void set_line_text(const class QString&txt);
       
-      enum timer_mode_t { TIMER_CALLUP, TIMER_END, TIMER_END_WARN, TIMER_STOP };
+      enum timer_mode_t { TIMER_CALLUP, TIMER_END, TIMER_END_WARN, TIMER_STOP,TIMER_PREP  };
       void set_time_value(int val, timer_mode_t mode);
 
 	// Toggle fullscreen mode. Return true if the result leaves


### PR DESCRIPTION
Display text shows 'PREP' prior to starting the call up timer, and 'STOP' after the end timer has stopped.